### PR TITLE
Update SpaceBotsList URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See more examples [here](/examples).
  - [lbots.org](https://lbots.org) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.LBots))
  - [listmybots.com](https://listmybots.com) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.ListMyBots))
  - [mythicalbots.xyz](https://mythicalbots.xyz) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.MythicalBots))
- - [space-bot-list.org](https://space-bot-list.org) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.SpaceBotsList))
+ - [space-bot-list.xyz](https://space-bot-list.xyz) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.SpaceBotsList))
  - [top.gg](https://top.gg) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.TopGG))
  - [wonderbotlist.com](https://wonderbotlist.com) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.WonderBotList))
  - [yabl.xyz](yabl.xyz) ([docs](https://dbots.readthedocs.io/en/latest/api.html#dbots.YABL))

--- a/dbots/service.py
+++ b/dbots/service.py
@@ -1502,11 +1502,11 @@ class SpaceBotsList(Service):
     Represents the Space Bots List service.
     
     .. seealso::
-        - `Space Bots List Website <https://space-bot-list.org/>`_
+        - `Space Bots List Website <https://space-bot-list.xyz/>`_
         - `Space Bots List API Documentation <https://spacebots.gitbook.io/tutorial-en/>`_
     """
 
-    BASE_URL = 'https://space-bot-list.org/api'
+    BASE_URL = 'https://space-bot-list.xyz/api'
 
     @staticmethod
     def aliases() -> list:


### PR DESCRIPTION
Space Bots List has moved to a similar domain with a different TLD. (`.org` -> `.xyz`)